### PR TITLE
Fix invalid default used for settings_file parameter [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,11 @@ orbs:
   maven: circleci/maven@dev:alpha
   orb-tools: circleci/orb-tools@9.0
 
+executors:
+  machine:
+    machine:
+      image: ubuntu-1604:202004-01
+
 # Pipeline parameters
 parameters:
   # These pipeline parameters are required by the "trigger-integration-tests-workflow"
@@ -83,8 +88,15 @@ workflows:
       # an example job
       - integration-test-1
       - maven/test:
+          name: test-without-settings
           test_results_path: sample_app/target/surefire-reports
           app_src_directory: sample_app
+      - maven/test:
+          name: test-with-settings
+          executor: machine
+          test_results_path: sample_app/target/surefire-reports
+          app_src_directory: sample_app
+          settings_file: $M2_HOME/conf/settings.xml
 
       # publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
@@ -102,7 +114,8 @@ workflows:
           publish-version-tag: false
           requires:
             - integration-test-1
-            - maven/test
+            - test-with-settings
+            - test-without-settings
           filters:
             branches:
               only: master

--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -13,9 +13,9 @@ description: |
   present in the `working_directory`.
 parameters:
   settings_file:
-        description: Specify a custom settings file to use (optional)
-        type: string
-        default: pom.xml
+    description: Specify a custom settings file to use (optional)
+    type: string
+    default: ""
   steps:
     type: steps
   maven_command:
@@ -33,20 +33,14 @@ steps:
       command: find . -name 'pom.xml' | sort | xargs cat > /tmp/maven_cache_seed
   - restore_cache:
       key: maven-{{ checksum "/tmp/maven_cache_seed" }}
-  - when:
-      condition: << parameters.settings_file >>
-      steps:
-        - run:
-            name: Install Dependencies
-            working_directory: << parameters.app_src_directory >>
-            command: << parameters.maven_command >> dependency:go-offline --settings '<< parameters.settings_file >>'
-  - unless:
-      condition: << parameters.settings_file >>
-      steps:
-        - run:
-            name: Install Dependencies
-            working_directory: << parameters.app_src_directory >>
-            command: << parameters.maven_command >> dependency:go-offline
+  - run:
+      name: Install Dependencies
+      working_directory: << parameters.app_src_directory >>
+      command: |
+        if [ -n "<< parameters.settings_file >>" ]; then
+          set -- "$@" --settings "<< parameters.settings_file >>"
+        fi
+        << parameters.maven_command >> dependency:go-offline "$@"
   - steps: << parameters.steps >>
   - save_cache:
       paths:

--- a/src/jobs/parallel_test.yml
+++ b/src/jobs/parallel_test.yml
@@ -18,7 +18,7 @@ parameters:
   settings_file:
     description: Specify a custom settings file to use (optional)
     type: string
-    default: pom.xml
+    default: ""
   maven_command:
     description: Specify a custom path for invoking maven
     type: string
@@ -83,18 +83,13 @@ steps:
       settings_file: << parameters.settings_file >>
       app_src_directory: << parameters.app_src_directory >>
       steps:
-        - when:
-            condition: << parameters.settings_file >>
-            steps:
-              - run:
-                  name: Run Tests
-                  command: << parameters.maven_command >> << parameters.command >> -Dsurefire.excludesFile=.circleci/tests/surefire_classnames_ignore_list -Dfailsafe.excludesFile=.circleci/tests/failsafe_classnames_ignore_list --settings '<< parameters.settings_file >>'
-        - unless:
-            condition: << parameters.settings_file >>
-            steps:
-              - run:
-                  name: Run Tests
-                  app_src_directory: << parameters.app_src_directory >>
-                  command: << parameters.maven_command >> << parameters.command >> -Dsurefire.excludesFile=.circleci/tests/surefire_classnames_ignore_list -Dfailsafe.excludesFile=.circleci/tests/failsafe_classnames_ignore_list
+        - run:
+            name: Run Tests
+            working_directory: << parameters.app_src_directory >>
+            command: |
+              if [ -n "<< parameters.settings_file >>" ]; then
+                set -- "$@" --settings "<< parameters.settings_file >>"
+              fi
+              << parameters.maven_command >> << parameters.command >> -Dsurefire.excludesFile=.circleci/tests/surefire_classnames_ignore_list -Dfailsafe.excludesFile=.circleci/tests/failsafe_classnames_ignore_list "$@"
   - process_test_results:
       test_results_path: << parameters.test_results_path >>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -21,7 +21,7 @@ parameters:
   settings_file:
     description: Specify a custom settings file to use (optional)
     type: string
-    default: pom.xml
+    default: ""
   maven_command:
     description: Specify a custom path for invoking maven
     type: string
@@ -33,19 +33,13 @@ steps:
       settings_file: << parameters.settings_file >>
       app_src_directory: << parameters.app_src_directory >>
       steps:
-        - when:
-            condition: << parameters.settings_file >>
-            steps:
-              - run:
-                  name: Run Tests
-                  working_directory: << parameters.app_src_directory >>
-                  command: << parameters.maven_command >> << parameters.command >> --settings '<< parameters.settings_file >>';
-        - unless:
-            condition: << parameters.settings_file >>
-            steps:
-              - run:
-                  name: Run Tests
-                  working_directory: << parameters.app_src_directory >>
-                  command: << parameters.maven_command >> << parameters.command >>;
+        - run:
+            name: Run Tests
+            working_directory: << parameters.app_src_directory >>
+            command: |
+              if [ -n "<< parameters.settings_file >>" ]; then
+                set -- "$@" --settings "<< parameters.settings_file >>"
+              fi
+              << parameters.maven_command >> << parameters.command >> "$@"
   - process_test_results:
       test_results_path: << parameters.test_results_path >>


### PR DESCRIPTION
As per https://github.com/CircleCI-Public/maven-orb/issues/3 , currently the default value used for `--settings` is an invalid one, leading to a warning whenever the command is run.

This fix resolves the warning by only passing in the `--settings` option when a non-blank value is set for the `settings_file` parameter.