### PR TITLE
[semver:minor] Make validating dependencies optional

### DIFF
--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -27,7 +27,7 @@ parameters:
     type: string
     default: ''
   verify_dependencies:
-    description: Verify dependencies are valid and available from pubic sources
+    description: Verify dependencies are valid and available from public sources
     type: boolean
     default: true
 steps:

--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -26,7 +26,7 @@ parameters:
     description: Useful when the source of your maven project is nott in the root directory of your git repo. Supply the name of the directory or relative path of the directory containing your source code.
     type: string
     default: ''
-  verify_dependenceis:
+  verify_dependencies:
     description: Verify dependencies are valid and available from pubic sources
     type: boolean
     default: true
@@ -47,7 +47,7 @@ steps:
   - run:
       name: Verify dependencies
       working_directory: << parameters.app_src_directory >>
-      when: << parameters.verify_dependenceis >>
+      when: << parameters.verify_dependencies >>
       command: << parameters.maven_command >> dependency:go-offline "$@"
   - steps: << parameters.steps >>
   - save_cache:

--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -44,11 +44,13 @@ steps:
         if [ -n "<< parameters.settings_file >>" ]; then
           set -- "$@" --settings "<< parameters.settings_file >>"
         fi
-  - run:
-      name: Verify dependencies
-      working_directory: << parameters.app_src_directory >>
-      when: << parameters.verify_dependencies >>
-      command: << parameters.maven_command >> dependency:go-offline "$@"
+  - when:
+      condition: << parameters.verify_dependencies >>
+      steps:
+        - run:
+            name: Verify dependencies
+            working_directory: << parameters.app_src_directory >>
+            command: << parameters.maven_command >> dependency:go-offline "$@"
   - steps: << parameters.steps >>
   - save_cache:
       paths:

--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -26,6 +26,10 @@ parameters:
     description: Useful when the source of your maven project is nott in the root directory of your git repo. Supply the name of the directory or relative path of the directory containing your source code.
     type: string
     default: ''
+  verify_dependenceis:
+    description: Verify dependencies are valid and available from pubic sources
+    type: boolean
+    default: true
 steps:
   - run:
       name: Generate Cache Checksum
@@ -40,7 +44,11 @@ steps:
         if [ -n "<< parameters.settings_file >>" ]; then
           set -- "$@" --settings "<< parameters.settings_file >>"
         fi
-        << parameters.maven_command >> dependency:go-offline "$@"
+  - run:
+      name: Verify dependencies
+      working_directory: << parameters.app_src_directory >>
+      when: << parameters.verify_dependenceis >>
+      command: << parameters.maven_command >> dependency:go-offline "$@"
   - steps: << parameters.steps >>
   - save_cache:
       paths:


### PR DESCRIPTION
Validating dependencies with `dependency:go-offline` in multi-package projects that have interdependencies will fail when updating the version numbers. This is because the project has not yet been built and the dependencies are not available from public sources.

This changes updates the `with_cache` command to optionally execute the `dependency:go-offline` goal based on a parameter. The default is for the dependencies to be checked and allows for the them to be omitted using a new _verify_dependencies_ parameter.