### PR TITLE
[semver:minor] Use a newer version of the maven dependency plugin

### DIFF
--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -40,7 +40,7 @@ steps:
         if [ -n "<< parameters.settings_file >>" ]; then
           set -- "$@" --settings "<< parameters.settings_file >>"
         fi
-        << parameters.maven_command >> dependency:go-offline "$@"
+        << parameters.maven_command >> org.apache.maven.plugins:maven-dependency-plugin:3.1.2:go-offline "$@"
   - steps: << parameters.steps >>
   - save_cache:
       paths:


### PR DESCRIPTION
Use a newer version of the maven dependency plugin than the default to solve issues with go-offline in multi-module projects with module dependencies.

Fixes #4.