### PR TITLE
use newer maven dependency plugin

### DIFF
--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -50,7 +50,7 @@ steps:
         - run:
             name: Verify dependencies
             working_directory: << parameters.app_src_directory >>
-            command: << parameters.maven_command >> dependency:go-offline "$@"
+            command: << parameters.maven_command >> org.apache.maven.plugins:maven-dependency-plugin:3.1.2:go-offline "$@"
   - steps: << parameters.steps >>
   - save_cache:
       paths:


### PR DESCRIPTION
As discussed in issue #4 , handling dependencies with multi-package maven projects does not work well. A newer version of the maven dependency plugin was added with PR #17 , but it looks like it was inadvertently overwritten as part of fixing merge conflicts in PR #14, which also made updates to better handle multi-package projects.

This PR keeps the optional validation in `with_cache`, but adds back the newer maven-dependency-plugin.