### PR TITLE
Fix working directory parameter

### DIFF
--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -37,7 +37,7 @@ parameters:
 steps:
   - run:
       name: Generate Cache Checksum
-      working_directory: $CIRCLE_WORKING_DIRECTORY/<< parameters.app_src_directory >>
+      working_directory: << parameters.app_src_directory >>
       command: << include(scripts/gen-cache-checksum.sh) >>
   - restore_cache:
       key: maven-{{ checksum "/tmp/maven_cache_seed" }}


### PR DESCRIPTION
The `working_directory` parameter for the run command doesn't do any expansion of env vars, so this command does not work as expected. Given the working_directory is relative to `$CIRCLE_WORKING_DIRECTORY` including the env var in the path is redundant. You can also see this in other steps in this command.