### PR TITLE
Support partial cache restores

### DIFF
--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -34,13 +34,21 @@ parameters:
     description: Specify the Maven Dependency Plugin
     type: string
     default: "3.1.2"
+  cache_name:
+    description: The cache's name prefix to allow for multiple caches and/or cache invalidation.
+    type: string
+    default: "maven"
 steps:
   - run:
       name: Generate Cache Checksum
       working_directory: << parameters.app_src_directory >>
       command: << include(scripts/gen-cache-checksum.sh) >>
   - restore_cache:
-      key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+      keys:
+        # Try to restore a cache made from the most recent build using our pom.xml
+        - << parameters.cache_name >>-{{ checksum "/tmp/maven_cache_seed" }}
+        # ... but if not, try anything with the same cache prefix as it's better than nothing.
+        - << parameters.cache_name >>-
   - when:
       condition: << parameters.verify_dependencies >>
       steps:
@@ -56,4 +64,4 @@ steps:
   - save_cache:
       paths:
         - ~/.m2/repository
-      key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+      key: << parameters.cache_name >>-{{ checksum "/tmp/maven_cache_seed" }}

--- a/src/jobs/parallel_test.yml
+++ b/src/jobs/parallel_test.yml
@@ -55,6 +55,10 @@ parameters:
     description: Specify the Maven Dependency Plugin
     type: string
     default: "3.1.2"
+  cache_name:
+    description: The cache's name prefix to allow for multiple caches and/or cache invalidation.
+    type: string
+    default: "maven"
 
 steps:
   - checkout
@@ -73,6 +77,7 @@ steps:
       maven_command: << parameters.maven_command >>
       dependency_plugin_version: << parameters.dependency_plugin_version >>
       verify_dependencies: << parameters.verify_dependencies >>
+      cache_name: << parameters.cache_name >>
       steps:
         - run:
             name: Run Tests

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -34,6 +34,10 @@ parameters:
     description: Specify the Maven Dependency Plugin
     type: string
     default: "3.1.2"
+  cache_name:
+    description: The cache's name prefix to allow for multiple caches and/or cache invalidation.
+    type: string
+    default: "maven"
 
 steps:
   - checkout
@@ -43,6 +47,7 @@ steps:
       maven_command: << parameters.maven_command >>
       dependency_plugin_version: << parameters.dependency_plugin_version >>
       verify_dependencies: << parameters.verify_dependencies >>
+      cache_name: << parameters.cache_name >>
       steps:
         - run:
             name: Run Tests


### PR DESCRIPTION
Fixes #44

As-is, the command `with_cache` either provides a perfect cache, or none at all. This means that if the pom.xml has changed at all, you get "none at all", which is not ideal and doesn't follow CircleCI recommended practise.

This PR enhances `with_cache` to provide multiple keys to the restore_cache command, so that it can do a "partial cache restore" if the pom.xml file has been modified.
The `with_cache` command has also gained an extra parameter, "cache_name" (which defaults to "maven" in order to preserve existing behavior), in order to allow easier cache invalidation (as per CircleCI guideance)
The `test` and `parallel_test` jobs also have this extra parameter which they pass through to `with_cache`.

TL;DR: Changes to pom.xml will now result in a partial cache restore instead of no cache, resolving issue #44.
